### PR TITLE
feat: add native Windows setup script (setup_ollama.ps1) for MIE Classifier

### DIFF
--- a/ISSR_MIE_Classifier/ISSRMIEclassifier/setup_ollama.ps1
+++ b/ISSR_MIE_Classifier/ISSRMIEclassifier/setup_ollama.ps1
@@ -1,0 +1,61 @@
+Write-Host "Setting up Ollama MIE Classification Model..." -ForegroundColor Cyan
+
+# 1. Wait for Ollama to be ready
+Write-Host "Waiting for Ollama to be ready..."
+$ollamaReady = $false
+while (-not $ollamaReady) {
+    try {
+        $response = Invoke-WebRequest -Uri "http://localhost:11434/api/tags" -Method Get -ErrorAction Stop
+        if ($response.StatusCode -eq 200) { $ollamaReady = $true }
+    }
+    catch {
+        Write-Host "Ollama not ready yet, waiting..."
+        Start-Sleep -Seconds 2
+    }
+}
+Write-Host "Ollama is ready!" -ForegroundColor Green
+
+# 2. Check if MIE model already exists
+$existingModels = ollama list
+if ($existingModels -match "mie-expert") {
+    Write-Host "MIE Expert model already exists" -ForegroundColor Green
+}
+else {
+    Write-Host "Creating MIE Expert model..." -ForegroundColor Yellow
+    
+    # Navigate to the models folder where the 'Modelfile' is located
+    Set-Location "ollama/models"
+    
+    # Run the creation command
+    ollama create mie-expert -f Modelfile
+    
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "MIE Expert model created successfully!" -ForegroundColor Green
+    }
+    else {
+        Write-Host "Failed to create MIE Expert model" -ForegroundColor Red
+        exit 1
+    }
+    # Return to previous directory
+    Set-Location ..\..
+}
+
+# 3. Test the model
+Write-Host "Testing MIE Expert model..." -ForegroundColor Cyan
+$testPayload = @{
+    model = "mie-expert"
+    prompt = "Test article: U.S. military conducted airstrikes in Syria. Is this an MIE?"
+    stream = $false
+} | ConvertTo-Json
+
+try {
+    $testResponse = Invoke-RestMethod -Uri "http://localhost:11434/api/generate" -Method Post -Body $testPayload -ContentType "application/json"
+    Write-Host "Response received:"
+    Write-Host $testResponse.response -ForegroundColor Gray
+}
+catch {
+    Write-Host "Test failed." -ForegroundColor Red
+}
+
+Write-Host ""
+Write-Host "Ollama setup complete! You can now run the MIE classification system." -ForegroundColor Green


### PR DESCRIPTION
### Description
The current `setup_ollama.sh` script utilizes Bash commands incompatible with standard Windows PowerShell environments. This creates a barrier for Windows-based contributors attempting to set up the local Ollama MIE model.

This PR introduces `setup_ollama.ps1`, a native PowerShell equivalent that:
1.  Checks for the Ollama service status.
2.  Creates the `mie-expert` model using the existing Modelfile.
3.  Performs a verification test to ensure the model responds correctly.

### Testing
- **Environment:** Windows 11, PowerShell 7 / VS Code Terminal.
- **Verification:** Ran the script successfully. The model was created, and the test payload returned a valid JSON response with `classification: "MIE"` (screenshot available upon request).

### Related Issue
Addresses the cross-platform compatibility gap in the MIE Classifier setup instructions.