### PR TITLE
docs: fix outdated NLTK download command in README

### DIFF
--- a/ISSR_MIE_Classifier/ISSRMIEclassifier/README.md
+++ b/ISSR_MIE_Classifier/ISSRMIEclassifier/README.md
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 
 3. **Download Required NLTK Data**
 ```bash
-python -c "import nltk; nltk.download('punkt'); nltk.download('averaged_perceptron_tagger'); nltk.download('maxent_ne_chunker'); nltk.download('words')"
+python -c "import nltk; nltk.download('punkt'); nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng'); nltk.download('maxent_ne_chunker_tab'); nltk.download('words')"
 ```
 
 4. **Setup Ollama (Optional but Recommended)**


### PR DESCRIPTION
### Description
The current NLTK download command in `ISSR_MIE_Classifier/ISSRMIEclassifier/README.md` references outdated package names (`averaged_perceptron_tagger`, `maxent_ne_chunker`) which cause `Resource not found` errors on modern NLTK installations.

This PR updates the command to use the current package names (`averaged_perceptron_tagger_eng`, `maxent_ne_chunker_tab`, `punkt_tab`) required for successful execution.

### Verification
- **Issue:** Running `python main.py` failed with `Resource averaged_perceptron_tagger not found`.
- **Fix:** Running the updated download command resolved the error and allowed the classifier to initialize correctly.

### Related Issue
Fixes dependency installation errors for new contributors setting up the environment.