### PR TITLE
Fix incorrect bounding box variables in yawn detection scripts

### DIFF
--- a/ISSR_Fatigue_detection/yawn/noYawn.py
+++ b/ISSR_Fatigue_detection/yawn/noYawn.py
@@ -48,7 +48,7 @@ for video in video_list:
 
         for box in result.boxes:
             x0,y0,x1,y1=box.xyxy.cpu().numpy().astype(int)[0]
-            xc,yc,width_bbox,height_bbox=result.boxes.xywhn.cpu().numpy()[0]
+            xc,yc,width_bbox,height_bbox=box.xywhn.cpu().numpy()[0]
             label_string_yawn=f'{no_yawn_number} {xc} {yc} {width_bbox} {height_bbox}\n'
             label_list.append(label_string_yawn)
             
@@ -60,7 +60,7 @@ for video in video_list:
                 eye_number=0
             else:
                 eye_number=1
-            x0,y0,x1,y1=box.xyxy.cpu().numpy().astype(int)[0]
+            x0,y0,x1,y1=box_eyes.xyxy.cpu().numpy().astype(int)[0]
             xc_eyes,yc_eyes,width_bbox_eyes,height_bbox_eyes=box_eyes.xywhn.cpu().numpy()[0]
             label_string_eyes=f'{eye_number} {xc_eyes} {yc_eyes} {width_bbox_eyes} {height_bbox_eyes}\n'
             cv2.rectangle(frame,(x0,y0),(x1,y1),(255,0,0),2)
@@ -73,7 +73,6 @@ for video in video_list:
             break
         with open(save_label_path,'w') as f:
             f.writelines(label_list)
-        f.close()
         cv2.imwrite(save_image_path,frame2)
         frame_count+=1
     

--- a/ISSR_Fatigue_detection/yawn/yawn_SPIGA_folder.py
+++ b/ISSR_Fatigue_detection/yawn/yawn_SPIGA_folder.py
@@ -93,11 +93,10 @@ for video in video_list:
                 
                     cv2.imwrite(image_path,frame2)
                     # Saving label .txt file to a label folder
-                    xc,yc,width_bbox,height_bbox=result.boxes.xywhn.cpu().numpy()[0]
+                    xc,yc,width_bbox,height_bbox=box.xywhn.cpu().numpy()[0]
                     label_string_yawn=f'{yawn_number} {xc} {yc} {width_bbox} {height_bbox}\n'
                     with open(label_path,'a') as f:
                         f.write(label_string_yawn) 
-                    f.close()
             else:
                 if yawn_AR>1.0:
                     eyes_results=model_eyes.predict(frame2)
@@ -126,11 +125,10 @@ for video in video_list:
                     cv2.imwrite(image_path,frame2)
                     # Saving label .txt file to a label folder
                     
-                    xc,yc,width_bbox,height_bbox=result.boxes.xywhn.cpu().numpy()[0]
+                    xc,yc,width_bbox,height_bbox=box.xywhn.cpu().numpy()[0]
                     label_string_yawn=f'{yawn_number} {xc} {yc} {width_bbox} {height_bbox}\n'
                     with open(label_path,'a') as f:
                         f.write(label_string_yawn) 
-                    f.close()
                     
 
             cv2.putText(frame,f"Yawn Ratio:{yawn_AR}",(20,50),cv2.FONT_HERSHEY_COMPLEX,2,(0,0,0),2)

--- a/ISSR_Fatigue_detection/yawn/yawn_SPIGA_single.py
+++ b/ISSR_Fatigue_detection/yawn/yawn_SPIGA_single.py
@@ -89,11 +89,10 @@ while cap.isOpened():
                
                 cv2.imwrite(image_path,frame2)
                 # Saving label .txt file to a label folder
-                xc,yc,width_bbox,height_bbox=result.boxes.xywhn.cpu().numpy()[0]
+                xc,yc,width_bbox,height_bbox=box.xywhn.cpu().numpy()[0]
                 label_string_yawn=f'{yawn_number} {xc} {yc} {width_bbox} {height_bbox}\n'
                 with open(label_path,'a') as f:
                     f.write(label_string_yawn) 
-                f.close()
         else:
             if yawn_AR>1.0:
                 eyes_results=model_eyes.predict(frame2)
@@ -122,11 +121,10 @@ while cap.isOpened():
                 cv2.imwrite(image_path,frame2)
                 # Saving label .txt file to a label folder
                 
-                xc,yc,width_bbox,height_bbox=result.boxes.xywhn.cpu().numpy()[0]
+                xc,yc,width_bbox,height_bbox=box.xywhn.cpu().numpy()[0]
                 label_string_yawn=f'{yawn_number} {xc} {yc} {width_bbox} {height_bbox}\n'
                 with open(label_path,'a') as f:
                     f.write(label_string_yawn) 
-                f.close()
                 
 
         cv2.putText(frame,f"Yawn Ratio:{yawn_AR}",(20,50),cv2.FONT_HERSHEY_COMPLEX,2,(0,0,0),2)


### PR DESCRIPTION
Found a couple of bounding box bugs in the fatigue detection scripts:

**noYawn.py:**
- `result.boxes.xywhn.cpu().numpy()[0]` always grabs the first detection regardless of which `box` the loop is iterating over. Changed to `box.xywhn` so each face gets its own coordinates in the label file.
- In the eyes loop, `box.xyxy` was used instead of `box_eyes.xyxy`, so the rectangle was drawn on the face bounding box rather than the eye bounding box. Fixed to `box_eyes.xyxy`.
- Removed a redundant `f.close()` after a `with` block (file is already closed by the context manager).

**yawn_SPIGA_single.py and yawn_SPIGA_folder.py:**
- Same `result.boxes.xywhn` -> `box.xywhn` fix.
- Same redundant `f.close()` cleanup.