### PR TITLE
Add missing soundfile dependency to Communication Analysis Tool

### DIFF
--- a/ISSR_Communication_Analysis_Tool_Samuel_Kalu/requirements.txt
+++ b/ISSR_Communication_Analysis_Tool_Samuel_Kalu/requirements.txt
@@ -14,3 +14,4 @@ vaderSentiment==3.3.2
 faster-whisper==1.1.1
 networkx==3.3
 gdown==5.2.0
+soundfile==0.12.1


### PR DESCRIPTION
`pipeline.py` imports `soundfile` (as `sf`) for audio file handling, but the package isn't listed in `requirements.txt`. This causes an `ImportError` on fresh installs.

Added `soundfile==0.12.1` to the Communication Analysis Tool's requirements.